### PR TITLE
Updates for ggplot2 v3.3.0

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,6 @@
 linters: with_defaults(
-    line_length_linter = NULL,
-    commented_code_linter = NULL,
-    NULL
+    line_length_linter = NULL, # 122
+    commented_code_linter = NULL, # 73
+    object_name_linter = NULL, # 7
+    dummy_linter = NULL
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Imports: dplyr,
     utils,
     hexbin,
     progress
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 Collate:
     'autocog.R'
     'known_cog_groups.R'

--- a/R/add_cog_group.R
+++ b/R/add_cog_group.R
@@ -27,7 +27,7 @@ add_cog_group <- function(
   assert_function(fn)
   # assert_logical(verbose, len = 1, any.missing = FALSE)
 
-  cog_group <- data_frame(
+  cog_group <- tibble(
     name,
     fields = list(fields),
     description = description,

--- a/R/add_cog_group_.R
+++ b/R/add_cog_group_.R
@@ -406,7 +406,7 @@ add_cog_group(
   ),
   "count information for grouped data",
   function(x, y, ...) {
-    dt <- data_frame(x, y)
+    dt <- tibble(x, y)
 
     counts <- dt %>% group_by(x, y) %>% count()
 
@@ -441,7 +441,7 @@ add_cog_group(
   ),
   "count information for grouped data",
   function(x, group, ...) {
-    data_frame(x, group) %>%
+    tibble(x, group) %>%
       group_by(group) %>%
       count() ->
     counts
@@ -650,7 +650,7 @@ add_cog_group(
     )
 
     params <- suppressMessages(ggplot2::StatSmooth$setup_params(dt, params))
-    core_params <- list(formula, data = dt, weight = dt$weights)
+    core_params <- list(formula, data = dt, weights = dt$weights)
 
     mod <- do.call(lm, c(core_params, params$method.args))
 
@@ -737,7 +737,7 @@ add_cog_group(
     dt <- data.frame(x = x, y = y, weights = weights)
 
     params <- suppressMessages(ggplot2::StatSmooth$setup_params(dt, params))
-    core_params <- list(formula, data = dt, weight = dt$weights, span = span)
+    core_params <- list(formula, data = dt, weights = dt$weights, span = span)
 
     mod <- do.call(loess, c(core_params, params$method.args))
     infos <- mod[c(
@@ -797,7 +797,7 @@ add_cog_group(
     }
 
     group_counts <- step_path %>%
-      group_by_("x") %>%
+      group_by(x) %>%
       count() %>%
       filter(n > 1)
 
@@ -805,7 +805,7 @@ add_cog_group(
       multi_groups <- group_counts$x
       grouped_step_path <- step_path[step_path$x %in% multi_groups, ]
       heights <- grouped_step_path %>%
-        group_by_("x") %>%
+        group_by(x) %>%
         summarise(
           min = min(y),
           max = max(y),

--- a/R/add_cog_group_.R
+++ b/R/add_cog_group_.R
@@ -414,7 +414,7 @@ add_cog_group(
 
     if (any(is_na_xy)) {
       na_count <- counts$n[is_na_xy]
-      counts <- counts %>% filter_(!is_na_xy)
+      counts <- counts %>% filter(!is_na_xy)
     } else {
       na_count <- 0
     }
@@ -449,7 +449,7 @@ add_cog_group(
     na_group <- is.na(counts$group)
     if (any(na_group)) {
       na_count <- counts$n[na_group]
-      counts <- counts %>% filter_(!na_group)
+      counts <- counts %>% filter(!na_group)
     } else {
       na_count <- 0
     }

--- a/R/add_layer_cogs.R
+++ b/R/add_layer_cogs.R
@@ -69,7 +69,7 @@ add_layer_cogs <- function(
 
   known_layer_cogs_ <<- bind_rows(
     known_layer_cogs_,
-    data_frame(
+    tibble(
       kind,
       name,
       cog_groups = list(cog_groups),

--- a/R/autocog.R
+++ b/R/autocog.R
@@ -7,7 +7,7 @@ simplify_cogs <- function(cog_list) {
   not_duplicated <- !duplicated(cogs, fromLast = TRUE)
   cogs[not_duplicated] %>%
     lapply(list) %>%
-    as_data_frame()
+    as_tibble()
 }
 
 

--- a/R/cog_spec.R
+++ b/R/cog_spec.R
@@ -19,7 +19,7 @@
 #'
 #' # set up data
 #' p <- ggplot2::qplot(Sepal.Length, Sepal.Width, data = iris, geom = c("point", "smooth"))
-#' dt <- tibble::data_frame(panel = list(p))
+#' dt <- tibble::tibble(panel = list(p))
 #'
 #' # compute cognostics like normal
 #' add_panel_cogs(dt)

--- a/R/field_info.R
+++ b/R/field_info.R
@@ -50,5 +50,5 @@ field_info <- function(
   assert_choice(dimension, c("x", "y", "z", "group", "any"))
   assert_choice(type, c("continuous", "discrete", "date", "any"))
 
-  data_frame(dimension, type)
+  tibble(dimension, type)
 }

--- a/R/known_cog_groups.R
+++ b/R/known_cog_groups.R
@@ -1,7 +1,7 @@
 
 
 
-known_cog_groups_ <- data_frame(
+known_cog_groups_ <- tibble::tibble(
   # Name of autocog
   name = character(0),
   # Fields required

--- a/R/known_layer_cogs.R
+++ b/R/known_layer_cogs.R
@@ -6,7 +6,7 @@
 #   cognostics: [String!]! # list of all cognostics names. ex: univariate_counts, univariate_continuous
 # }
 
-known_layer_cogs_ <- data_frame(
+known_layer_cogs_ <- tibble::tibble(
   # plot mechanism (ggplot2, rbokeh, plotly, etc.)
   kind = character(0),
 

--- a/R/layer_info.R
+++ b/R/layer_info.R
@@ -48,17 +48,22 @@ layer_info.ggplot <- function(p, keep = TRUE, ...) {
 
     layer_name <- snake_class(layer$geom)
 
+    val_or_empty <- function(x) {
+      ret <- c(x, "")
+      ret[1]
+    }
+
     ret_name <- switch(layer_name,
-      "geom_point" = switch(snake_class(layer$position),
+      "geom_point" = switch(val_or_empty(snake_class(layer$position)),
         # "position_jitter" = "geom_jitter",
         switch(
-          snake_class(layer$stat),
+          val_or_empty(snake_class(layer$stat)),
           "stat_qq" = "geom_qq",
           "stat_sum" = "geom_count",
           "geom_point"
         )
       ),
-      "geom_smooth" = switch(as.character(layer$stat_params$method),
+      "geom_smooth" = switch(val_or_empty(as.character(layer$stat_params$method)),
         "loess" = "geom_smooth_loess",
         "lm" = "geom_smooth_lm",
         "geom_smooth"

--- a/R/plot_cogs.R
+++ b/R/plot_cogs.R
@@ -94,7 +94,7 @@ plot_cogs <- function(p, ..., spec = TRUE, verbose = FALSE) {
         args <- append(dt_i_list, layer_item$params)
         ans <- do.call(fn, args)
         if (is.null(ans)) return(ans)
-        as_data_frame(ans)
+        as_tibble(ans)
       })
 
       # store values by name store_name
@@ -136,7 +136,7 @@ get_layer_info <- function(p, keep = TRUE, ...) {
     assert_character(item$name, len = 1, any.missing = FALSE)
     assert_data_frame(item$data)
     assert_numeric(item$layer_num, len = 1, any.missing = FALSE)
-    item$data <- as_data_frame(item$data)
+    item$data <- as_tibble(item$data)
     item
   })
 

--- a/R/plot_cogs.R
+++ b/R/plot_cogs.R
@@ -25,9 +25,9 @@ plot_cogs <- function(p, ..., spec = TRUE, verbose = FALSE) {
   lapply(layer_info, function(layer_item) {
     # get the layer cog info
     layer_cog_group <- known_layer_cogs() %>%
-      filter_(
-        ~ kind == plot_class_val,
-        ~ name == layer_item$name
+      filter(
+        .data[["kind"]] == plot_class_val,
+        .data[["name"]] == layer_item$name
       )
 
     # if the layer isnt registered, message and return early

--- a/man/cog_spec.Rd
+++ b/man/cog_spec.Rd
@@ -5,15 +5,30 @@
 \alias{as_cog_specs}
 \title{Cognostic Specification}
 \usage{
-cog_spec(bivariate_continuous = TRUE, bivariate_counts = TRUE,
-  bivariate_step = TRUE, boxplot = TRUE,
-  density_2d_continuous = TRUE, density_continuous = TRUE,
-  grouped_counts = TRUE, grouped_testing = TRUE, hex_counts = TRUE,
-  histogram_counts = TRUE, linear_model = TRUE, loess_model = TRUE,
-  pairwise_counts = TRUE, quantile_quantile = TRUE,
-  scagnostics = TRUE, smooth_line = TRUE, square_counts = TRUE,
-  univariate_continuous = TRUE, univariate_counts = TRUE,
-  univariate_discrete = TRUE, ..., .keep_layer = TRUE)
+cog_spec(
+  bivariate_continuous = TRUE,
+  bivariate_counts = TRUE,
+  bivariate_step = TRUE,
+  boxplot = TRUE,
+  density_2d_continuous = TRUE,
+  density_continuous = TRUE,
+  grouped_counts = TRUE,
+  grouped_testing = TRUE,
+  hex_counts = TRUE,
+  histogram_counts = TRUE,
+  linear_model = TRUE,
+  loess_model = TRUE,
+  pairwise_counts = TRUE,
+  quantile_quantile = TRUE,
+  scagnostics = TRUE,
+  smooth_line = TRUE,
+  square_counts = TRUE,
+  univariate_continuous = TRUE,
+  univariate_counts = TRUE,
+  univariate_discrete = TRUE,
+  ...,
+  .keep_layer = TRUE
+)
 
 as_cog_specs(p, specs)
 }
@@ -45,7 +60,7 @@ cog_spec(.keep_layer = FALSE); FALSE
 
 # set up data
 p <- ggplot2::qplot(Sepal.Length, Sepal.Width, data = iris, geom = c("point", "smooth"))
-dt <- tibble::data_frame(panel = list(p))
+dt <- tibble::tibble(panel = list(p))
 
 # compute cognostics like normal
 add_panel_cogs(dt)

--- a/man/field_info.Rd
+++ b/man/field_info.Rd
@@ -4,8 +4,10 @@
 \alias{field_info}
 \title{Field Type Information}
 \usage{
-field_info(dimension = c("x", "y", "z", "group", "any"),
-  type = c("continuous", "discrete", "date", "any"))
+field_info(
+  dimension = c("x", "y", "z", "group", "any"),
+  type = c("continuous", "discrete", "date", "any")
+)
 }
 \arguments{
 \item{dimension}{field name. Use one of the listed options provided}

--- a/tests/testthat/test-layers.R
+++ b/tests/testthat/test-layers.R
@@ -8,7 +8,7 @@ test_that("ggplot2 layers", {
 
   p <- ggplot(iris, aes(Sepal.Length, Sepal.Width)) +
     geom_point() +
-    geom_smooth(method = "auto")
+    geom_smooth(method = "auto", formula = y ~ x)
 
   check_plot_count <- function(spec, count) {
     expect_silent({


### PR DESCRIPTION
All changes should be backwards compatible.  The only one that worries me is changing the data.frames to tibbles... but that's never a bad thing, right?

The only update due to ggplot2 directly is they dropped the formula in geom_smooth and then produce a default value message because it wasn't provided.  I don't like this change. 😞 